### PR TITLE
Update deprecated pr labeler version

### DIFF
--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -1,18 +1,24 @@
 version: 1
 labels:
   - label: "size/XS"
-    size-below: 10
+    size:
+      below: 10
   - label: "size/S"
-    size-above: 9
-    size-below: 30
+    size:
+      above: 9
+      below: 30
   - label: "size/M"
-    size-above: 29
-    size-below: 100
+    size:
+      above: 29
+      below: 100
   - label: "size/L"
-    size-above: 99
-    size-below: 500
+    size:
+      above: 99
+      below: 500
   - label: "size/XL"
-    size-above: 499
-    size-below: 1000
+    size:
+      above: 499
+      below: 1000
   - label: "size/XXL"
-    size-above: 999
+    size:
+      above: 999

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -31,7 +31,7 @@ jobs:
     # - "config/crd/bases/.*"  # generated CRDs
     # - "docs/apis/v*.md"      # generated API documentation,
     #                          # ex. docs/apis/v1alpha1.md
-    - uses: srvaroa/labeler@v0.9
+    - uses: srvaroa/labeler@master
       with:
         config_path: .github/configs/labeler.yml
       env:


### PR DESCRIPTION
Bump the version of the PR Labeler action, updating to the newer
configuration schema. The size configuration was changed a few versions
ago. I'm looking to remove support so I'm sending some PRs to the very
few repos that still rely on it.

I updated the reference to the action to master. This actually uses the
latest stable version so it should avoid any unintended breakage.

Thanks for using the action!

Signed-off-by: Galo Navarro <anglorvaroa@gmail.com>

<!--
Thanks for sending a pull request!

Please add one of the following icons to the title of this PR:

    ⚠️ (:warning:, a major or breaking change)
    ✨ (:sparkles:, feature additions)
    🐛 (:bug:, patch and bugfixes)
    📖 (:book:, documentation or proposals)
    🌱 (:seedling:, minor or other)

Some other tips:

    1. If this is your first time filing a PR, please read our contributor
       guidelines for submitting a change at https://vm-operator.readthedocs.io/en/stable/start/contrib/submit-change/.
    2. If this PR is unfinished, please prefix the subject with "WIP:".

Finally, before filing the PR, please delete all of the HTML comments.
-->

**What does this PR do, and why is it needed?**

<!-- A clear and concise description of the PR and the problem it solves / feature it introduces / value it adds to the project. -->


**Which issue(s) is/are addressed by this PR?** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #


**Are there any special notes for your reviewer**:

<!-- Anything else you would like the reviewers to know about this PR. -->


**Please add a release note if necessary**:

<!--
Write your release note:

    1. Enter your extended release note in the below block. If the PR requires
       additional action from users switching to the new release, please include
       the string "action required".
    2. If a release note is not required, please write "NONE".
-->

```release-note

```